### PR TITLE
feat: Add support for storing and retrieving coin pair lists for back…

### DIFF
--- a/BinanceTestnet/Database/ReportGenerator.cs
+++ b/BinanceTestnet/Database/ReportGenerator.cs
@@ -19,7 +19,7 @@ namespace BinanceTestnet.Database
         /// Generates a summary report for a specific session, grouped by TakeProfitMultiplier and Interval.
         /// </summary>
         /// 
-        public void GenerateSummaryReport(string sessionId, string outputPath)
+        public void GenerateSummaryReport(string sessionId, string outputPath, string coinPairsFormatted)
         {
             // Fetch all trades for the session
             var trades = _tradeLogger.GetTrades(sessionId);
@@ -138,12 +138,14 @@ namespace BinanceTestnet.Database
                 reportTable.Rows.Add("Short Trades", tradeDistribution.ShortTrades);
                 reportTable.Rows.Add("Average Trade Duration (minutes)", tradeDistribution.AverageDuration.ToString("F2").Replace(",", "."));
 
+                // Add the active coin pair list to the report
+                reportTable.Rows.Add("Active Coin Pairs", coinPairsFormatted);
+
                 // Export the report to CSV
                 var groupOutputPath = Path.Combine(outputPath, $"{interval}_{takeProfitMultiplier}_report.csv");
                 ExportToCsv(reportTable, groupOutputPath);
             }
         }
-
 
         /// <summary>
         /// Calculates performance metrics for a specific list of trades.

--- a/BinanceTestnet/Strategies/RSIMomentumStrategy.cs
+++ b/BinanceTestnet/Strategies/RSIMomentumStrategy.cs
@@ -35,7 +35,7 @@ public class RSIMomentumStrategy : StrategyBase
             if (rsiValues.Count == 0) return;
 
             // Console.WriteLine($"[DEBUG] RSI State Map Count: {rsiStateMap.Count}");
-            Console.WriteLine($"[DEBUG] RSI State for {symbol}: {(rsiStateMap.ContainsKey(symbol) ? rsiStateMap[symbol] : "NOT SET")}");
+            //Console.WriteLine($"[DEBUG] RSI State for {symbol}: {(rsiStateMap.ContainsKey(symbol) ? rsiStateMap[symbol] : "NOT SET")}");
 
 
             // **Always evaluate first before setting initial state**
@@ -114,18 +114,18 @@ public class RSIMomentumStrategy : StrategyBase
             if (rsi >= 71)
             {
                 rsiStateMap[symbol] = "OVERBOUGHT";
-                Console.WriteLine($"[STATE] {symbol} is set to OVERBOUGHT at RSI {rsi} on {DateTimeOffset.FromUnixTimeMilliseconds(kline.CloseTime).UtcDateTime}.");
+                //Console.WriteLine($"[STATE] {symbol} is set to OVERBOUGHT at RSI {rsi} on {DateTimeOffset.FromUnixTimeMilliseconds(kline.CloseTime).UtcDateTime}.");
                 return;
             }
             if (rsi <= 29)
             {
                 rsiStateMap[symbol] = "OVERSOLD";
-                Console.WriteLine($"[STATE] {symbol} is set to OVERSOLD at RSI {rsi} on {DateTimeOffset.FromUnixTimeMilliseconds(kline.CloseTime).UtcDateTime}.");
+                //Console.WriteLine($"[STATE] {symbol} is set to OVERSOLD at RSI {rsi} on {DateTimeOffset.FromUnixTimeMilliseconds(kline.CloseTime).UtcDateTime}.");
                 return;
             }
         }
         rsiStateMap[symbol] = "NEUTRAL";
-        Console.WriteLine($"[STATE] {symbol} is set to NEUTRAL.");
+        //Console.WriteLine($"[STATE] {symbol} is set to NEUTRAL.");
     }
 
     private async Task EvaluateRSIConditions(List<decimal> rsiValues, string symbol, List<Kline> klines)

--- a/BinanceTestnet/Strategies/StrategyRunner.cs
+++ b/BinanceTestnet/Strategies/StrategyRunner.cs
@@ -79,14 +79,14 @@ namespace BinanceLive.Strategies
         {
             var strategies = new List<StrategyBase>();
 
-            strategies.Add(new CandleDistributionReversalStrategy(_client, _apiKey, _orderManager, _wallet));
-            strategies.Add(new EmaStochRsiStrategy(_client, _apiKey, _orderManager, _wallet));
+            // strategies.Add(new CandleDistributionReversalStrategy(_client, _apiKey, _orderManager, _wallet));
+            // strategies.Add(new EmaStochRsiStrategy(_client, _apiKey, _orderManager, _wallet));
             //  strategies.Add(new EnhancedMACDStrategy(_client, _apiKey, _orderManager, _wallet));
             //   strategies.Add(new FVGStrategy(_client, _apiKey, _orderManager, _wallet));
             // strategies.Add(new RSIMomentumStrategy(_client, _apiKey, _orderManager, _wallet));
             // strategies.Add(new SMAExpansionStrategy(_client, _apiKey, _orderManager, _wallet));
-            // strategies.Add(new MACDStandardStrategy(_client, _apiKey, _orderManager, _wallet));
-            //   strategies.Add(new RsiDivergenceStrategy(_client, _apiKey, _orderManager, _wallet));
+            //  strategies.Add(new MACDStandardStrategy(_client, _apiKey, _orderManager, _wallet));
+            strategies.Add(new RsiDivergenceStrategy(_client, _apiKey, _orderManager, _wallet));
             // strategies.Add(new IchimokuCloudStrategy(_client, _apiKey, _orderManager, _wallet));         
             // strategies.Add(new FibonacciRetracementStrategy(_client, _apiKey, _orderManager, _wallet));        
             // strategies.Add(new AroonStrategy(_client, _apiKey, _orderManager, _wallet));


### PR DESCRIPTION
…testing and reporting

- Added a new `CoinPairLists` table to store coin pair lists with `StartDateTime` and `EndDateTime`.
- Implemented logic to update the coin pair list every 20 cycles during live trading.
- Added fallback mechanism for backtesting when `targetDateTime` is earlier than the first `StartDateTime`.
- Improved reporting to include the active coin pair list for better context.
- Updated database schema and methods to handle time ranges for coin pair lists.

This change enables accurate backtesting by using historical coin pair lists and ensures live trading uses up-to-date lists.